### PR TITLE
Browser smoke test for app loading

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,8 +14,6 @@ import { PostHogUserIdentify } from "@/components/utilities/posthog/posthog-user
 import { Providers } from "@/components/utilities/providers"
 import { TailwindIndicator } from "@/components/utilities/tailwind-indicator"
 import { cn } from "@/lib/utils"
-import { ClerkProvider } from "@clerk/nextjs"
-import { auth } from "@clerk/nextjs/server"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import "./globals.css"
@@ -32,7 +30,24 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  const { userId } = await auth()
+  const disableClerk = process.env.DISABLE_CLERK === "1"
+
+  let userId: string | null = null
+  let ClerkProvider: React.ComponentType<{ children: React.ReactNode }>
+
+  if (disableClerk) {
+    ClerkProvider = ({ children }) => <>{children}</>
+  } else {
+    const [{ ClerkProvider: RealClerkProvider }, { auth }] = await Promise.all([
+      import("@clerk/nextjs"),
+      import("@clerk/nextjs/server")
+    ])
+    const authRes = await auth()
+    userId = authRes.userId
+    ClerkProvider = RealClerkProvider as unknown as React.ComponentType<{
+      children: React.ReactNode
+    }>
+  }
 
   if (userId) {
     const profileRes = await getProfileByUserIdAction(userId)

--- a/mckays-app-template/.next/cache/config.json
+++ b/mckays-app-template/.next/cache/config.json
@@ -1,0 +1,5 @@
+{
+	"telemetry": {
+		"notifiedAt": "1754900028347"
+	}
+}

--- a/mckays-app-template/.next/trace
+++ b/mckays-app-template/.next/trace
@@ -1,0 +1,1 @@
+[{"name":"next-dev","duration":467013,"timestamp":1831710842,"id":1,"tags":{},"startTime":1754900027906,"traceId":"42800cd2d2d0c5a3"}]

--- a/mckays-app-template/middleware.ts
+++ b/mckays-app-template/middleware.ts
@@ -1,0 +1,36 @@
+/*
+<ai_context>
+Contains middleware for protecting routes, checking user authentication, and redirecting as needed.
+</ai_context>
+*/
+
+import type { NextRequest } from "next/server"
+import { NextResponse } from "next/server"
+
+export default async function middleware(req: NextRequest) {
+  if (process.env.DISABLE_CLERK === "1") {
+    return NextResponse.next()
+  }
+
+  const { clerkMiddleware, createRouteMatcher } = await import(
+    "@clerk/nextjs/server"
+  )
+
+  const isProtectedRoute = createRouteMatcher(["/todo(.*)"])
+
+  return clerkMiddleware(async (auth, req) => {
+    const { userId, redirectToSignIn } = await auth()
+
+    if (!userId && isProtectedRoute(req)) {
+      return redirectToSignIn({ returnBackUrl: "/login" })
+    }
+
+    if (userId && isProtectedRoute(req)) {
+      return NextResponse.next()
+    }
+  })(req)
+}
+
+export const config = {
+  matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"]
+}


### PR DESCRIPTION
Add `DISABLE_CLERK` environment variable to bypass Clerk authentication for headless smoke testing.

---
<a href="https://cursor.com/background-agent?bcId=bc-bac53a27-babd-4698-870a-7cb7555fb01f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bac53a27-babd-4698-870a-7cb7555fb01f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

